### PR TITLE
Sokak haritası katmanı ve şeffaflık eklemeleri

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9427199806484048"
      crossorigin="anonymous"></script>
 
-     
+
     <link href="https://fonts.googleapis.com/css?family=Ubuntu" rel="stylesheet">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.4.0/dist/leaflet.css"
   integrity="sha512-puBpdR0798OZvTTbP4A8Ix/l+A4dHDD0DGqYW6RQ+9jxkRFclaxxQb/SJAWZfWAkuyeQUytO7+7N4QKrDh+drA=="
@@ -56,7 +56,7 @@
 
 
     </style>
-    
+
 </head>
 <body>
     <div id="sidebar" class="leaflet-sidebar collapsed">
@@ -96,8 +96,8 @@
                 href="https://mapelse.github.io/global_vs30/"><b> Turkiye Vs30 Deprem Sarsinti Potansiyeli Haritasi icin     tıklayınız</b></a> </p>
 
                 <p style="margin-top:1px; font-family:'Ubuntu', sans-serif; line-height: 20px" align=justify ></p><a href="https://mapelse.github.io/fayHatlari/"><b>Türkiye Önemli Fay Hatları ve 6 Siddetinin Uzerinde Gerceklesen Depremler Haritası için tıklayınız</b></a> </p>
-                
-                <p style="margin-top:30px; font-family:'Ubuntu', sans-serif; line-height: 20px" align=justify> Not:Bu bilgiler genel bilgilendirme amaçlıdır ve profesyonel tavsiye olarak kabul edilmemelidir. 
+
+                <p style="margin-top:30px; font-family:'Ubuntu', sans-serif; line-height: 20px" align=justify> Not:Bu bilgiler genel bilgilendirme amaçlıdır ve profesyonel tavsiye olarak kabul edilmemelidir.
                     Mevcut verilerin kullanışlı bir şekilde sunumundan ibarettir.
                     Herhangi bir karar vermeden önce uygun uzmanlardan tavsiye almanız önerilir. </p>
                 <p style="margin-top:30px; font-family:'Ubuntu', sans-serif; line-height: 20px" align=justify >Bu harita Twitter'da gördüğüm <a href="https://twitter.com/Paleosismolog/status/1183796422300311552" target="_blank">şu paylaşım</a>'dan esinelenerek hazırlanmıştır. Veri İstanbul Büyükşehir Belediyesi tarafından oluşturulmuştur. Haritayı hazırlamaktaki temel amaç beklenen büyük İstanbul depremi öncesi zeminin jeolojik yapısı hakkında bir fikir vermektir.</p>
@@ -135,7 +135,7 @@
 
                 <!-- just added this button as a reminder for using this bar as button container in future works-->
                 <!-- <button type="button" class="btn btn-primary">Primary</button> -->
-                        
+
             </div>
 
             <div class="leaflet-sidebar-pane" id="profile">
@@ -183,8 +183,13 @@
           attribution: 'Map data &copy; OpenStreetMap contributors'
         });*/
 
-        var osm=L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-          attribution: 'Map data &copy; OpenStreetMap contributors'
+        var osm=L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+          attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        });
+
+        var osmTransparent = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+          attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+          opacity: 0.6
         });
 
         var Esri_WorldImagery = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
@@ -223,9 +228,12 @@ var esriImageryLabels = L.featureGroup([esriImagery, esriLabels]);
             "Uydu": esriImageryLabels
            };
         var tileLayers= {
-        	 "Istanbul Jeoloji": mapbox
-
+        	 "Istanbul Jeoloji": mapbox,
+        	 "Uydu": esriImageryLabels
         }
+        var overlayLayers = {
+          "OSM Labels": osmTransparent
+        };
 
         //initiating the side bar
         var sidebar = L.control.sidebar({ container: 'sidebar', position: 'right' })
@@ -245,7 +253,7 @@ var esriImageryLabels = L.featureGroup([esriImagery, esriLabels]);
       }).addTo(map);
 
        //Adding all layers and feautes to map
-        L.control.layers(tileLayers,baseLayers,{
+        L.control.layers(tileLayers, overlayLayers, {
         	position:"topleft",
         	collapsed: true
         }).addTo(map);

--- a/index.html
+++ b/index.html
@@ -234,9 +234,6 @@ var esriImageryLabels = L.featureGroup([esriImagery, esriLabels]);
         var mapbox=  L.tileLayer('tiles/{z}/{x}/{y}.png');
 
 
-
-
-
         //initiating the map variable
         var map = L.map('map', {
           zoom: 10,
@@ -249,16 +246,10 @@ var esriImageryLabels = L.featureGroup([esriImagery, esriLabels]);
         map.setMinZoom(9);
         map.setMaxZoom(14);
 
-        //grouping base layers defined above and assigning them to a var
-        var baseLayers = {
-            "Uydu": esriImageryLabels
-           };
-        var tileLayers= {
-        	 "Istanbul Jeoloji": mapbox,
-        	 "Uydu": esriImageryLabels
-        }
+        //grouping overlay layers defined above and assigning them to a var
         var overlayLayers = {
-          "Şehir Haritası": osmTransparent
+          "Şehir Haritası": osmTransparent,
+          "Uydu": esriImageryLabels,
         };
 
         //initiating the side bar
@@ -279,10 +270,19 @@ var esriImageryLabels = L.featureGroup([esriImagery, esriLabels]);
       }).addTo(map);
 
        //Adding all layers and feautes to map
-        L.control.layers(tileLayers, overlayLayers, {
+        L.control.layers({}, overlayLayers, {
         	position:"topleft",
-        	collapsed: true
+            collapsed: false
         }).addTo(map);
+
+      // Make Uydu and Şehir Haritası mutually exclusive (radio buttons)
+      map.on('overlayadd', function(e) {
+        if (e.name === 'Uydu') {
+          map.removeLayer(osmTransparent);
+        } else if (e.name === 'Şehir Haritası') {
+          map.removeLayer(esriImageryLabels);
+        }
+      });
 
       // Opacity control
       var OpacityControl = L.Control.extend({
@@ -298,10 +298,15 @@ var esriImageryLabels = L.featureGroup([esriImagery, esriLabels]);
       });
       new OpacityControl().addTo(map);
 
-      // Update opacity on slider change
+      // Update opacity on slider change - controls whichever overlay is currently selected
       document.getElementById('opacitySlider').addEventListener('input', function() {
         var value = this.value / 100;
-        osmTransparent.setOpacity(value);
+        if (map.hasLayer(esriImageryLabels)) {
+          esriImageryLabels.setOpacity(value);
+        }
+        if (map.hasLayer(osmTransparent)) {
+          osmTransparent.setOpacity(value);
+        }
         document.getElementById('opacityValue').textContent = this.value;
       });
     </script>

--- a/index.html
+++ b/index.html
@@ -258,7 +258,7 @@ var esriImageryLabels = L.featureGroup([esriImagery, esriLabels]);
         	 "Uydu": esriImageryLabels
         }
         var overlayLayers = {
-          "OSM Labels": osmTransparent
+          "Şehir Haritası": osmTransparent
         };
 
         //initiating the side bar

--- a/index.html
+++ b/index.html
@@ -246,11 +246,15 @@ var esriImageryLabels = L.featureGroup([esriImagery, esriLabels]);
         map.setMinZoom(9);
         map.setMaxZoom(14);
 
-        //grouping overlay layers defined above and assigning them to a var
+        //grouping overlay layers (top layers) defined above and assigning them to a var
+        // `mapbox` remains always visible as the base layer
         var overlayLayers = {
           "Şehir Haritası": osmTransparent,
-          "Uydu": esriImageryLabels,
+          "Uydu": esriImageryLabels
         };
+
+        // Show 'Şehir Haritası' by default
+        map.addLayer(osmTransparent);
 
         //initiating the side bar
         var sidebar = L.control.sidebar({ container: 'sidebar', position: 'right' })
@@ -269,20 +273,11 @@ var esriImageryLabels = L.featureGroup([esriImagery, esriLabels]);
       	position: "topleft"
       }).addTo(map);
 
-       //Adding all layers and feautes to map
-        L.control.layers({}, overlayLayers, {
+       //Adding overlay layers to the control (checkboxes). We'll enforce exclusivity below.
+        L.control.layers(null, overlayLayers, {
         	position:"topleft",
             collapsed: false
         }).addTo(map);
-
-      // Make Uydu and Şehir Haritası mutually exclusive (radio buttons)
-      map.on('overlayadd', function(e) {
-        if (e.name === 'Uydu') {
-          map.removeLayer(osmTransparent);
-        } else if (e.name === 'Şehir Haritası') {
-          map.removeLayer(esriImageryLabels);
-        }
-      });
 
       // Opacity control
       var OpacityControl = L.Control.extend({
@@ -298,17 +293,48 @@ var esriImageryLabels = L.featureGroup([esriImagery, esriLabels]);
       });
       new OpacityControl().addTo(map);
 
+      // Make Uydu and Şehir Haritası mutually exclusive (simulate radio buttons)
+      map.on('overlayadd', function(e) {
+        if (e.name === 'Uydu') {
+          if (map.hasLayer(osmTransparent)) map.removeLayer(osmTransparent);
+        } else if (e.name === 'Şehir Haritası') {
+          if (map.hasLayer(esriImageryLabels)) map.removeLayer(esriImageryLabels);
+        }
+      });
+
+      // Helper to set opacity on a layer or a group of layers
+      function setLayerOpacity(layer, value) {
+        if (!layer) return;
+        if (typeof layer.setOpacity === 'function') {
+          layer.setOpacity(value);
+          return;
+        }
+        if (typeof layer.eachLayer === 'function') {
+          layer.eachLayer(function(l) {
+            if (typeof l.setOpacity === 'function') l.setOpacity(value);
+          });
+          return;
+        }
+        try {
+          var container = layer.getContainer && layer.getContainer();
+          if (container) container.style.opacity = value;
+        } catch (err) {}
+      }
+
       // Update opacity on slider change - controls whichever overlay is currently selected
       document.getElementById('opacitySlider').addEventListener('input', function() {
         var value = this.value / 100;
         if (map.hasLayer(esriImageryLabels)) {
-          esriImageryLabels.setOpacity(value);
-        }
-        if (map.hasLayer(osmTransparent)) {
-          osmTransparent.setOpacity(value);
+          setLayerOpacity(esriImageryLabels, value);
+        } else if (map.hasLayer(osmTransparent)) {
+          setLayerOpacity(osmTransparent, value);
         }
         document.getElementById('opacityValue').textContent = this.value;
       });
+
+      // initialize overlays' opacity to the slider's default value
+      setLayerOpacity(osmTransparent, document.getElementById('opacitySlider').value / 100);
+      setLayerOpacity(esriImageryLabels, document.getElementById('opacitySlider').value / 100);
     </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -54,6 +54,32 @@
             color: #AAA;
         }
 
+        .opacity-control {
+            background: white;
+            padding: 10px 15px;
+            border-radius: 4px;
+            box-shadow: 0 1px 5px rgba(0,0,0,0.2);
+            font-family: 'Ubuntu', sans-serif;
+            font-size: 12px;
+        }
+
+        .opacity-control label {
+            display: block;
+            margin-bottom: 8px;
+            font-weight: bold;
+        }
+
+        .opacity-control input[type="range"] {
+            width: 100%;
+            cursor: pointer;
+        }
+
+        .opacity-value {
+            text-align: center;
+            margin-top: 5px;
+            font-size: 11px;
+            color: #666;
+        }
 
     </style>
 
@@ -257,6 +283,27 @@ var esriImageryLabels = L.featureGroup([esriImagery, esriLabels]);
         	position:"topleft",
         	collapsed: true
         }).addTo(map);
+
+      // Opacity control
+      var OpacityControl = L.Control.extend({
+        options: {
+          position: 'topleft'
+        },
+        onAdd: function(map) {
+          var container = L.DomUtil.create('div', 'opacity-control');
+          container.innerHTML = '<label>Harita Saydamlığı</label><input type="range" min="0" max="100" value="60" id="opacitySlider"><div class="opacity-value"><span id="opacityValue">60</span>%</div>';
+          L.DomEvent.disableClickPropagation(container);
+          return container;
+        }
+      });
+      new OpacityControl().addTo(map);
+
+      // Update opacity on slider change
+      document.getElementById('opacitySlider').addEventListener('input', function() {
+        var value = this.value / 100;
+        osmTransparent.setOpacity(value);
+        document.getElementById('opacityValue').textContent = this.value;
+      });
     </script>
 </body>
 </html>


### PR DESCRIPTION
Bu PR şu iyileştirmeleri içerir:

- Haritanın kullanışlılığını arttırmak için İstanbul'daki sokakları içeren yeni bir katman eklendi
- Hem uydu hem de sokak haritası için jeoloji haritasıyla karşılaştırmayı kolaylaştıracak şekilde şeffaflık slider'ı eklendi (closes #2)

https://github.com/user-attachments/assets/ccffdbbd-64f4-4061-8e12-90dcbe925d3a

